### PR TITLE
[Fix] #129 - (DiscoveryView) 카테고리 버튼 오토레이아웃 수정

### DIFF
--- a/TravelTale/Presentation/Discoveries/Discovery/View/DiscoveryView.swift
+++ b/TravelTale/Presentation/Discoveries/Discovery/View/DiscoveryView.swift
@@ -40,9 +40,8 @@ final class DiscoveryView: BaseView {
     }
     
     private let categoryStackView = UIStackView().then {
-        $0.spacing = 16
         $0.alignment = .center
-        $0.distribution = .fillProportionally
+        $0.distribution = .equalSpacing
     }
     
     lazy var touristSpotButton = UIButton().then {


### PR DESCRIPTION
## 개요 📢
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #129  -->

버튼 spacing을 없애고, stackView의 equalSpacing으로 주어서 간격을 조절하였습니다.

> iphone 15
<img src = "https://github.com/TEAM-OMG-iOS/TravelTale/assets/95227560/f0f65f42-8a81-421a-8cd6-52cdb70982d2" width = 300 />

> iphone se
<img src = "https://github.com/TEAM-OMG-iOS/TravelTale/assets/95227560/a61e3560-1e3e-4d74-a576-c9cc338bedb1" width = 300 />


## PR 유형 📌
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist ✅
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).


## Related Issues 💭
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #129 
